### PR TITLE
Changed PipeOptions to asynchronous and transmission mode to Byte to resolve a pipe write hang

### DIFF
--- a/LegacyWrapper/Transport/PipeServer.cs
+++ b/LegacyWrapper/Transport/PipeServer.cs
@@ -34,10 +34,11 @@ namespace LegacyWrapper.Transport
         private void OpenPipeServer()
         {
             PipeDirection pipeDirection = PipeDirection.InOut;
-            PipeTransmissionMode pipeTransmissionMode = PipeTransmissionMode.Message;
+            PipeTransmissionMode pipeTransmissionMode = PipeTransmissionMode.Byte;
+            PipeOptions pipeOptions = PipeOptions.Asynchronous;
             int maxNumberOfServerInstances = 1;
 
-            _pipe = new NamedPipeServerStream(_pipeToken.Token, pipeDirection, maxNumberOfServerInstances, pipeTransmissionMode);
+            _pipe = new NamedPipeServerStream(_pipeToken.Token, pipeDirection, maxNumberOfServerInstances, pipeTransmissionMode, pipeOptions);
             _pipe.WaitForConnection();
         }
 

--- a/LegacyWrapperClient/Client/WrapperClient.cs
+++ b/LegacyWrapperClient/Client/WrapperClient.cs
@@ -44,6 +44,20 @@ namespace LegacyWrapperClient.Client
             string errorMessage = "Returned parameters differ in length from passed parameters";
             Raise.InvalidDataException.If(callData.Parameters.Length != callResult.Parameters.Length, errorMessage);
 
+            // HUGE HACK
+            for (int i = 0; i < callResult.Parameters.Length; i++)
+            {
+                if (callResult.Parameters[i] is int[])
+                {
+                    int[] pi = (int[])callResult.Parameters[i];
+                    pi.CopyTo((int[])callData.Parameters[i], 0);
+                }
+                else
+                {
+                    callData.Parameters[i] = callResult.Parameters[i];
+                }
+            }
+
             Array.Copy(callResult.Parameters, callData.Parameters, callResult.Parameters.Length);
         }
 

--- a/LegacyWrapperClient/Transport/PipeStreamFactory.cs
+++ b/LegacyWrapperClient/Transport/PipeStreamFactory.cs
@@ -15,9 +15,9 @@ namespace LegacyWrapperClient.Transport
 
         public virtual PipeStream GetConnectedPipeStream(PipeToken pipeToken)
         {
-            NamedPipeClientStream pipe = new NamedPipeClientStream(LocalPipeUrl, pipeToken.Token, PipeDirection.InOut);
+            NamedPipeClientStream pipe = new NamedPipeClientStream(LocalPipeUrl, pipeToken.Token, PipeDirection.InOut, PipeOptions.Asynchronous);
             pipe.Connect();
-            pipe.ReadMode = PipeTransmissionMode.Message;
+            pipe.ReadMode = PipeTransmissionMode.Byte;
 
             return pipe;
         }


### PR DESCRIPTION
Not sure why I was hanging on writing to the named pipe, but tried these changes based on this thread:

https://stackoverflow.com/questions/8069172/duplex-named-pipe-hangs-on-a-certain-write

It solves the problem for me.